### PR TITLE
More geopackage compatibility / sql language support

### DIFF
--- a/src/geometry/gpkg.clj
+++ b/src/geometry/gpkg.clj
@@ -831,7 +831,13 @@
                                    table-name
                                    (->geotools-schema table-name spec)
                                    conn)))
-             (catch java.lang.IllegalArgumentException _))
+             (catch java.lang.IllegalArgumentException _)
+             (catch java.sql.SQLException e
+               ;; We expect this exception if the table already exists, it's fine
+               ;; and we just assume things are OK. Things will break later if the
+               ;; existing table has the wrong shape
+               (when-not (.contains (.getMessage e) "[SQLITE_CONSTRAINT_UNIQUE]")
+                 (throw e))))
 
            (when add-spatial-index
              (try (.createSpatialIndex geopackage feature-entry)

--- a/src/geometry/gpkg.clj
+++ b/src/geometry/gpkg.clj
@@ -751,9 +751,6 @@
   if :accessor is not provided, the column name is used to get values
   from each row for this column. Otherwise accessor is invoked on each
   row.
-
-  When writing non-spatial tables, you can use :not-null, :primary-key
-  and :foreign-key. These don't work for non-spatial tables at the moment.
   
   Because of how sqlite works, these are only guaranteed to take effect
   if the target table doesn't exist


### PR DESCRIPTION
Reasonably hefty change here:

- Adds some new keys to the geopackage write schema so you can say things like
    ```
    :primary-key :auto-increment
    :not-null true
    ```
- When a non-spatial table has an autoincrement primary key, adds it to geopackage_contents as an 'attribute' table. This is (a) spec compliant and (b) stops qgis being weird

- As a nicety, reads boolean values back out as bool for nonspatial tables

To allow the new schema features to work for spatial tables, I have had to go behind the back of geotools; we no longer call (GeoPackage/create) to add a new table, instead we execute our own SQL and then use a geotools private method to do the required housekeeping.

This may break in a future JVM version that's less generous about security, but will throw an exception early if it does.

Thoughts for review:

- Is this too ugly now? I think this is right at the limit of Geotools related hackery now I am using private internals.
- I've changed the behavior reading non-spatial tables (BOOLEAN columns now come in as true/false not 1/0)
- I've also changed the non-spatial write behaviour a little; I think previously we were opening two sqlite connections, one implicit in the geopackage constructor and one by hand to write through. I now get one out of the geopackage object instead. I think this can only reduce the risk of problems though.

There's a bit of mess around the processing of schemas which I think could be rationalised. I was thinking of doing this later, and adding some shorthands like 
   ```
   :schema {:foo :int :bar :string :fid :auto-increment :other_id :other_table/other_id}
   ==>
   {:foo {:type :int} :bar {:type :string} :fid {:type :integer :primary-key :auto-increment} :other_id {:type :integer :foreign-key :other_table/other_id}}
   etc
   ```
  at the same time